### PR TITLE
Improved gdbserver.rb to auto-locate CoIDE's gdbserver folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ data/*
 data/*.o
 data/*.elf
 data/*.map
+mkmf.log
 TEST1.txt
 TEST2.txt

--- a/mkmf.log
+++ b/mkmf.log
@@ -1,4 +1,0 @@
-find_executable: checking for gcc... -------------------- yes
-
---------------------
-

--- a/scripts/gdbserver.rb
+++ b/scripts/gdbserver.rb
@@ -1,4 +1,5 @@
-COIDE_PATH = "C:/CooCox/CoIDE_V2Beta/bin"
+# This will be the default path if auto-locate fails
+coide_gdbserver_path = "C:/CooCox/CoIDE_V2Beta/bin"
 
 # Load build script to help build C program
 load "scripts/cbuild.rb"
@@ -27,16 +28,31 @@ config = {
 GDBSERVER_FILE = "build/release/gdbserver.exe"
 MYFLASH_FILE   = "build/release/myFlash.exe"
 
+def auto_locate_coide_gdbserver_path
+  name = 'coflash'
+  program = `sh -c "which #{name}"`
+  if !program.empty?
+    return File.dirname program
+  else
+    raise ArgumentError,                                                  \
+          "Error: Can't locate CoIDE gdbserver path"                      \
+                if File.exists? coide_gdbserver_path
+  end
+  return coide_gdbserver_path
+end
+
 namespace :gdbserver do
-  gdb_target = "#{COIDE_PATH}/gdbserver.exe"
-  flash_target = "#{COIDE_PATH}/coflash.exe"
+  coide_gdbserver_path = auto_locate_coide_gdbserver_path
 
-  original_gdb = "#{COIDE_PATH}/gdbserverOriginal.exe"
-  original_flash = "#{COIDE_PATH}/coflashOriginal.exe"
+  gdb_target = File.join(coide_gdbserver_path, 'gdbserver.exe')
+  flash_target = File.join(coide_gdbserver_path, 'coflash.exe')
 
-  config_file =  "#{COIDE_PATH}/config"
-  gdb_config_file =  "#{COIDE_PATH}/GDBServerConfig.ini"
-  elfLocation_file = "#{COIDE_PATH}/ElfLocation.txt"
+  original_gdb = File.join(coide_gdbserver_path, 'gdbserverOriginal.exe')
+  original_flash = File.join(coide_gdbserver_path, 'coflashOriginal.exe')
+
+  config_file =  File.join(coide_gdbserver_path, 'config')
+  gdb_config_file = File.join(coide_gdbserver_path, 'GDBServerConfig.ini')
+  elfLocation_file = File.join(coide_gdbserver_path, 'ElfLocation.txt')
 
   desc 'Release gdbserver'
   task :release do

--- a/scripts/gdbserver.rb
+++ b/scripts/gdbserver.rb
@@ -1,6 +1,7 @@
 # This will be the default path if auto-locate fails
 coide_gdbserver_path = "C:/CooCox/CoIDE_V2Beta/bin"
 
+require 'pathname'
 # Load build script to help build C program
 load "scripts/cbuild.rb"
 
@@ -9,7 +10,12 @@ config = {
   :verbose      => :yes,
   :compiler     => 'gcc',
   :linker       => 'gcc',
-  :include_path => ['src', 'src/GDB', 'src/ARMSimulator', 'src/ElfReader', 'src/MyFlash'],
+  :include_path => ['src',
+                    'src/GDB',
+                    'src/ARMSimulator',
+                    'src/ElfReader',
+                    'src/FloatingPointInstructions',
+                    'src/MyFlash'],
   # :user_define  => ['CEXCEPTION_USE_CONFIG_FILE'],
 #  :library_path => 'lib',
   :library => ['ws2_32'],
@@ -28,21 +34,23 @@ config = {
 GDBSERVER_FILE = "build/release/gdbserver.exe"
 MYFLASH_FILE   = "build/release/myFlash.exe"
 
-def auto_locate_coide_gdbserver_path
-  name = 'coflash'
+def auto_locate_coide_gdbserver_path(default)
+  name = 'start_gdbserver.bat'
   program = `sh -c "which #{name}"`
   if !program.empty?
-    return File.dirname program
+    dirname = File.dirname program
+    dirname.gsub!(/^\/(\w+)/, '\1:') if Gem.win_platform?
+    return dirname
   else
     raise ArgumentError,                                                  \
           "Error: Can't locate CoIDE gdbserver path"                      \
-                if File.exists? coide_gdbserver_path
+                if File.exists? default
   end
-  return coide_gdbserver_path
+  return default
 end
 
 namespace :gdbserver do
-  coide_gdbserver_path = auto_locate_coide_gdbserver_path
+  coide_gdbserver_path = auto_locate_coide_gdbserver_path(coide_gdbserver_path)
 
   gdb_target = File.join(coide_gdbserver_path, 'gdbserver.exe')
   flash_target = File.join(coide_gdbserver_path, 'coflash.exe')
@@ -56,7 +64,7 @@ namespace :gdbserver do
 
   desc 'Release gdbserver'
   task :release do
-    dep_list = compile_all(['src/GDB', 'src/ARMSimulator', 'src/ElfReader', 'src'], 'build/release/host/c', config)
+    dep_list = compile_all(['src/GDB', 'src/ARMSimulator', 'src/ElfReader', 'src/FloatingPointInstructions', 'src'], 'build/release/host/c', config)
     link_all(getDependers(dep_list), GDBSERVER_FILE, config)
     Rake::Task[GDBSERVER_FILE].invoke
 
@@ -68,16 +76,18 @@ namespace :gdbserver do
   desc 'Build and deploy gdbserver + coflash'
   task :deploy => :release do
     if !up_to_date?(gdb_target, GDBSERVER_FILE)
-      if !File.exist? original_gdb
+      if !(File.exists? original_gdb)
         sh "mv #{gdb_target} #{original_gdb}"     #rename the original executable file
       end
+      puts "updating gdbserver.exe..."
       sh "cp #{GDBSERVER_FILE} #{gdb_target}"     #move to desire destination
     end
 
     if !up_to_date?(flash_target, MYFLASH_FILE)
-      if !File.exist? original_flash
+      if !File.exists? original_flash
         sh "mv #{flash_target} #{original_flash}"   #rename the original executable file
       end
+      puts "updating coflash.exe..."
       sh "cp #{MYFLASH_FILE} #{flash_target}"     #move to desire destination
     end
 
@@ -87,19 +97,21 @@ namespace :gdbserver do
 
   desc 'Revert to original gdbserver + coflash'
   task :revert do
-    if File.exist? original_gdb
+    if File.exists? original_gdb
+      puts "reverting gdbserver.exe..."
       sh "mv #{original_gdb} #{gdb_target}"
     end
-    if File.exist? original_flash
+    if File.exists? original_flash
+      puts "reverting coflash.exe..."
       sh "mv #{original_flash} #{flash_target}"
     end
-    if File.exist? config_file
+    if File.exists? config_file
       sh "rm #{config_file}"
     end
-    if File.exist? gdb_config_file
+    if File.exists? gdb_config_file
       sh "rm #{gdb_config_file}"
     end
-    if File.exist? elfLocation_file
+    if File.exists? elfLocation_file
       sh "rm #{elfLocation_file}"
     end
   end


### PR DESCRIPTION
This improvement does not need user to specify the folder of `CoIDE's gdbserver`. It will be auto-located, though the code is a quick hack. The implementation may fail because it relies on successfully finding `start_gdbserver.bat` file that is found in CoIDE's `/bin` folder. If the future version of CoIDE removes that file, then it will fail.

Also I updated the custom building of release code to include `/FloatingPointInstructions` source folder. This solves the linking error.
